### PR TITLE
Fix "Run on Google Cloud" URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ See `examples/gcloud-deploy.sh`
 
 Or use the easy button:
 
-[![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=http://github.com/google/triage-party)
+[![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/google/triage-party)


### PR DESCRIPTION
It appears the `cloudshell_open` command does not support `http` schemes and requires `https`.

Before this patch:
```
cloudshell_open --repo_url "http://github.com/google/triage-party" --page "shell"
[ ✖ ] Failed to clone git repository http://github.com/google/triage-party
Error: invalid git repo url: http://github.com/google/triage-party
```

After this patch:
```
cloudshell_open --repo_url "https://github.com/google/triage-party" --page "shell"
[ ✓ ] Cloned git repository https://github.com/google/triage-party.
[ ✓ ] Queried list of your GCP projects
[ ✓ ] Found 62 projects in your GCP account.
[ ? ] Choose a project to deploy this application:  [Use arrows to move, type to filter]
...
```