### PR TITLE
Support GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Triage Party is a stateless Go web application, configured via YAML. While it ha
 * Easily open groups of issues into browser tabs (must allow pop-ups)
 * Queries across multiple repositories
 * "Shift-Reload" for live data pull
+* GitHub Enterprise support (via `--github-api-url` cli flag)
 
 ## Triage Party in production
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,7 +37,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/google/go-github/v31/github"
 	"golang.org/x/oauth2"
 	"k8s.io/klog/v2"
 
@@ -48,6 +47,9 @@ import (
 )
 
 var (
+	// custom GitHub API URLs
+	githubAPIRawURL = flag.String("github-api-url", "", "GitHub API url to connect.  Please set this when you use GitHub Enterprise. This often is your GitHub Enterprise hostname. If the URL does not have the suffix \"/api/v3/\", it will be added automatically.")
+
 	// shared with tester
 	configPath     = flag.String("config", "", "configuration path")
 	persistBackend = flag.String("persist-backend", "", "Cache persistence backend (disk, mysql, cloudsql)")
@@ -78,7 +80,7 @@ func main() {
 
 	ctx := context.Background()
 
-	client := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+	client := triage.MustCreateGithubClient(*githubAPIRawURL, oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: triage.MustReadToken(*githubTokenFile, "GITHUB_TOKEN")},
 	)))
 

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -26,12 +26,14 @@ import (
 	"github.com/google/triage-party/pkg/persist"
 	"github.com/google/triage-party/pkg/triage"
 
-	"github.com/google/go-github/v31/github"
 	"golang.org/x/oauth2"
 	"k8s.io/klog/v2"
 )
 
 var (
+	// custom GitHub API URLs
+	githubAPIRawURL = flag.String("github-api-url", "", "base URL for GitHub API.  Please set this when you use GitHub Enterprise. This often is your GitHub Enterprise hostname. If the base URL does not have the suffix \"/api/v3/\", it will be added automatically.")
+
 	// shared with server
 	configPath      = flag.String("config", "", "configuration path")
 	persistBackend  = flag.String("persist-backend", "", "Cache persistence backend (disk, mysql, cloudsql)")
@@ -58,7 +60,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	client := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+	client := triage.MustCreateGithubClient(*githubAPIRawURL, oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: triage.MustReadToken(*githubTokenFile, "GITHUB_TOKEN")},
 	)))
 

--- a/pkg/triage/github.go
+++ b/pkg/triage/github.go
@@ -2,7 +2,9 @@ package triage
 
 import (
 	"fmt"
+	"github.com/google/go-github/v31/github"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -44,4 +46,15 @@ func MustReadToken(path string, env string) string {
 		klog.Exitf("github token impossibly small: %q", token)
 	}
 	return token
+}
+
+func MustCreateGithubClient(githubAPIRawURL string, httpClient *http.Client) *github.Client {
+	if githubAPIRawURL != "" {
+		client, err := github.NewEnterpriseClient(githubAPIRawURL, githubAPIRawURL, httpClient)
+		if err != nil {
+			klog.Exitf("unable to create GitHub client: %v", err)
+		}
+		return client
+	}
+	return github.NewClient(httpClient)
 }


### PR DESCRIPTION
Fixes #63 
The PR enables just to configure GitHub API endpoints.

I didn't use [`github.NewEnterpriseClient()` method](https://github.com/google/go-github/blob/v31.0.0/github/github.go#L310-L337) because this method does have a bug (https://github.com/google/go-github/pull/1510) in upload URL completion which has been fixed only on the master branch.

Although I'm not sure how to test my change (I mean CI actually), I confirmed this PR works for my own GitHub Enterprise manually.