### PR TITLE
 Improve refresh performance through better caching 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ COPY third_party /app/third_party/
 COPY $CFG /app/config.yaml
 
 # Run the server at a reasonable refresh rate
-CMD ["/app/main", "--min-refresh=25s", "--max-refresh=20m", "--config=/app/config.yaml", "--site=/app/site", "--3p=/app/third_party"]
+CMD ["/app/main", "--min-refresh=30s", "--max-refresh=7m30s", "--config=/app/config.yaml", "--site=/app/site", "--3p=/app/third_party"]

--- a/pkg/hubbub/cache.go
+++ b/pkg/hubbub/cache.go
@@ -2,47 +2,7 @@ package hubbub
 
 import (
 	"fmt"
-	"time"
-
-	"k8s.io/klog/v2"
 )
-
-// FlushSearchCache invalidates the in-memory search cache
-func (h *Engine) FlushSearchCache(org string, project string, olderThan time.Time) error {
-	h.flushIssueSearchCache(org, project, olderThan)
-	h.flushPRSearchCache(org, project, olderThan)
-	return nil
-}
-
-func (h *Engine) flushIssueSearchCache(org string, project string, olderThan time.Time) {
-	klog.Infof("flushIssues older than %s: %s/%s", olderThan, org, project)
-
-	keys := []string{
-		issueSearchKey(org, project, "open", 0),
-		issueSearchKey(org, project, "closed", closedIssueDays),
-	}
-
-	for _, key := range keys {
-		if err := h.cache.DeleteOlderThan(key, olderThan); err != nil {
-			klog.Warningf("delete %q: %v", key, err)
-		}
-	}
-}
-
-func (h *Engine) flushPRSearchCache(org string, project string, olderThan time.Time) {
-	klog.Infof("flushPRs older than %s: %s/%s", olderThan, org, project)
-
-	keys := []string{
-		issueSearchKey(org, project, "open", 0),
-		issueSearchKey(org, project, "closed", closedPRDays),
-	}
-
-	for _, key := range keys {
-		if err := h.cache.DeleteOlderThan(key, olderThan); err != nil {
-			klog.Warningf("delete %q: %v", key, err)
-		}
-	}
-}
 
 // issueSearchKey is the cache key used for issues
 func issueSearchKey(org string, project string, state string, days int) string {

--- a/pkg/hubbub/issue.go
+++ b/pkg/hubbub/issue.go
@@ -62,6 +62,7 @@ func (h *Engine) updateIssues(ctx context.Context, org string, project string, s
 		if err != nil {
 			return is, err
 		}
+		h.logRate(resp.Rate)
 
 		for _, i := range is {
 			if i.IsPullRequest() {
@@ -114,6 +115,8 @@ func (h *Engine) updateIssueComments(ctx context.Context, org string, project st
 		if err != nil {
 			return cs, err
 		}
+		h.logRate(resp.Rate)
+
 		allComments = append(allComments, cs...)
 		if resp.NextPage == 0 {
 			break

--- a/pkg/hubbub/log.go
+++ b/pkg/hubbub/log.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hubbub
+
+import (
+	"fmt"
+
+	"github.com/google/go-github/v31/github"
+	"k8s.io/klog/v2"
+)
+
+func (h *Engine) logRate(r github.Rate) {
+	msg := fmt.Sprintf("GitHub API hourly quota remaining: %d of %d, resets at %s", r.Remaining, r.Limit, r.Reset)
+
+	if r.Remaining < 25 {
+		klog.Error(msg)
+		return
+	}
+
+	if r.Remaining < 250 {
+		klog.Warning(msg)
+		return
+	}
+
+	if r.Remaining%100 == 1 {
+		klog.Info(msg)
+	}
+}

--- a/pkg/hubbub/pull_requests.go
+++ b/pkg/hubbub/pull_requests.go
@@ -55,9 +55,9 @@ func (h *Engine) updatePRs(ctx context.Context, org string, project string, stat
 		klog.Infof("Downloading %s pull requests for %s/%s (page %d)...", state, org, project, opt.Page)
 		prs, resp, err := h.client.PullRequests.List(ctx, org, project, opt)
 		if err != nil {
-			klog.Errorf("err")
 			return prs, err
 		}
+		h.logRate(resp.Rate)
 
 		for _, pr := range prs {
 			// Because PR searches do not support opt.Since
@@ -108,10 +108,12 @@ func (h *Engine) updatePRComments(ctx context.Context, org string, project strin
 	for {
 		klog.V(2).Infof("Downloading PR comments for %s/%s #%d (page %d)...", org, project, num, opt.Page)
 		cs, resp, err := h.client.PullRequests.ListComments(ctx, org, project, num, opt)
-		klog.V(2).Infof("Received %d comments", len(cs))
 		if err != nil {
 			return cs, err
 		}
+		h.logRate(resp.Rate)
+
+		klog.V(2).Infof("Received %d comments", len(cs))
 		allComments = append(allComments, cs...)
 		if resp.NextPage == 0 {
 			break

--- a/pkg/hubbub/search.go
+++ b/pkg/hubbub/search.go
@@ -46,7 +46,7 @@ func (h *Engine) SearchIssues(ctx context.Context, org string, project string, f
 
 	orgCutoff := time.Now().Add(h.memberRefresh * -1)
 	if orgCutoff.After(newerThan) {
-		klog.Infof("Setting org cutoff to %s", newerThan)
+		klog.V(1).Infof("Setting org cutoff to %s", newerThan)
 		orgCutoff = newerThan
 	}
 

--- a/pkg/triage/rule.go
+++ b/pkg/triage/rule.go
@@ -106,7 +106,7 @@ func SummarizeRuleResult(t Rule, cs []*hubbub.Conversation, seen map[string]*Rul
 
 // ExecuteRule executes a rule. seen is optional.
 func (p *Party) ExecuteRule(ctx context.Context, t Rule, seen map[string]*Rule, newerThan time.Time) (*RuleResult, error) {
-	klog.Infof("executing rule %q for results newer than %s", t.ID, logu.STime(newerThan))
+	klog.V(1).Infof("executing rule %q for results newer than %s", t.ID, logu.STime(newerThan))
 	rcs := []*hubbub.Conversation{}
 	var latest time.Time
 


### PR DESCRIPTION
Armed with a better understanding of GitHub API quotas, this PR does a couple of important things:

* Refresh cycles now share a cache when possible
* Cache flushing is no longer necessary for shift-reload
* GitHub API quota rates are now periodically logged

