### PR TITLE
support 'repo' filter that matches repo's full name

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -61,6 +61,9 @@ The second rule, `many-reactions`, is more fine-grained. It is only focused on i
 # Issue or PR title
 - title: [!]regex
 
+# GitHub repo full name (i.e. "org_name/repo_name")
+- repo: [!]regex
+
 # Internal tagging: particularly useful tags are:
 # - recv: updated by author more recently than a project member
 # - recv-q: updated by author with a question

--- a/pkg/hubbub/filter.go
+++ b/pkg/hubbub/filter.go
@@ -30,6 +30,10 @@ var (
 
 // Filter lets you do less.
 type Filter struct {
+	RawRepo     string `yaml:"repo,omitempty"`
+	repoRegex *regexp.Regexp
+	repoNegate bool
+
 	RawLabel    string `yaml:"label,omitempty"`
 	labelRegex  *regexp.Regexp
 	labelNegate bool
@@ -58,6 +62,31 @@ type Filter struct {
 	ClosedCommenters   string `yaml:"commenters-while-closed,omitempty"`
 	State              string `yaml:"state,omitempty"`
 }
+
+
+// LoadRepoRegex loads a new repo regex
+func (f *Filter) LoadRepoRegex() error {
+	repo, negateRepo := negativeMatch(f.RawRepo)
+
+	re, err := regex(repo)
+	if err != nil {
+		return err
+	}
+
+	f.repoRegex = re
+	f.repoNegate = negateRepo
+
+	return nil
+}
+
+func (f *Filter) RepoRegex() *regexp.Regexp {
+	return f.repoRegex
+}
+
+func (f *Filter) RepoNegate() bool {
+	return f.repoNegate
+}
+
 
 // LoadLabelRegex loads a new label reegx
 func (f *Filter) LoadLabelRegex() error {

--- a/pkg/hubbub/item.go
+++ b/pkg/hubbub/item.go
@@ -11,6 +11,7 @@ import (
 
 // GitHubItem is an interface that matches both GitHub Issues and PullRequests
 type GitHubItem interface {
+	GetRepository() *github.Repository
 	GetAssignee() *github.User
 	GetBody() string
 	GetComments() int

--- a/pkg/hubbub/match.go
+++ b/pkg/hubbub/match.go
@@ -65,6 +65,13 @@ func preFetchMatch(i GitHubItem, labels []*github.Label, fs []Filter) bool {
 			}
 		}
 
+		if f.RepoRegex() != nil && i.GetRepository() != nil {
+			if ok := matchNegateRegex(i.GetRepository().GetFullName(), f.RepoRegex(), f.RepoNegate()); !ok {
+				klog.V(2).Infof("#%d repo do not meet %s", i.GetNumber(), f.LabelRegex())
+				return false
+			}
+		}
+
 		if f.LabelRegex() != nil {
 			if ok := matchLabel(labels, f.LabelRegex(), f.LabelNegate()); !ok {
 				klog.V(2).Infof("#%d labels do not meet %s", i.GetNumber(), f.LabelRegex())

--- a/pkg/hubbub/pull_requests.go
+++ b/pkg/hubbub/pull_requests.go
@@ -145,7 +145,7 @@ func (h *Engine) PRSummary(pr *github.PullRequest, cs []*github.PullRequestComme
 		}
 	}
 
-	co := h.conversation(pr, cl, isMember(pr.GetAuthorAssociation()))
+	co := h.conversation(&pullRequest{pr}, cl, isMember(pr.GetAuthorAssociation()))
 	h.addEvents(co, timeline)
 
 	for _, t := range timeline {
@@ -175,4 +175,15 @@ func (h *Engine) PRSummary(pr *github.PullRequest, cs []*github.PullRequestComme
 
 	sort.Slice(co.Tags, func(i, j int) bool { return co.Tags[i].ID < co.Tags[j].ID })
 	return co
+}
+
+type pullRequest struct {
+	*github.PullRequest
+}
+
+func (pr *pullRequest) GetRepository() *github.Repository {
+	if pr.GetBase() == nil {
+		return nil
+	}
+	return pr.GetBase().GetRepo()
 }

--- a/pkg/hubbub/search.go
+++ b/pkg/hubbub/search.go
@@ -262,7 +262,7 @@ func (h *Engine) SearchPullRequests(ctx context.Context, org string, project str
 
 	for _, pr := range prs {
 		klog.V(3).Infof("Found PR #%d with labels: %+v", pr.GetNumber(), pr.Labels)
-		if !preFetchMatch(pr, pr.Labels, fs) {
+		if !preFetchMatch(&pullRequest{pr}, pr.Labels, fs) {
 			klog.V(4).Infof("PR #%d did not pass preFetchMatch :(", pr.GetNumber())
 			continue
 		}

--- a/pkg/triage/triage.go
+++ b/pkg/triage/triage.go
@@ -230,6 +230,12 @@ func processRules(raw map[string]Rule) (map[string]Rule, error) {
 		newfs := []hubbub.Filter{}
 
 		for _, f := range raw[id].Filters {
+			if f.RawRepo != "" {
+				err := f.LoadRepoRegex()
+				if err != nil {
+					return rules, fmt.Errorf("%q repo: %w", id, err)
+				}
+			}
 			if f.RawLabel != "" {
 				err := f.LoadLabelRegex()
 				if err != nil {


### PR DESCRIPTION
fixes #75 
The PR introduces `repo` filter that will match repo's full name.

- For issues, the filter matches repo's full name in which the issue lives
- For pull requests, the filter matches repo's full name in which its base branch lives (I think it is very intuitive)
  - I added `hubbub.pullRequest` type to convert `github.PullRequest` to `hubbub.GitHubItem`.