### PR TITLE
Fix 'tag: assigned' filter

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -109,6 +109,7 @@ Triage Party has an automatic tagging mechanism that adds annotations which can 
 * `recv-q`: the original author commented with a question more recently than a member of the project has commented (may be waiting on an answer from a project member)
 * `member-last`: a member of the organization was the last commenter
 * `author-last`: the original author was the last commenter
+* `assigned`: the issue or PR has been assigned to someone
 * `closed`: the issue or PR has been closed
 * `similar`: the issue or PR appears to be similar to another
 * `new-commits`: the PR has new commits since the last member response

--- a/pkg/hubbub/match.go
+++ b/pkg/hubbub/match.go
@@ -80,7 +80,7 @@ func preFetchMatch(i GitHubItem, labels []*github.Label, fs []Filter) bool {
 		}
 
 		// This state can be performed without downloading comments
-		if f.TagRegex() != nil && f.TagRegex().String() == "assigned" {
+		if f.TagRegex() != nil && f.TagRegex().String() == "^assigned$" {
 			// If assigned and no assignee, fail
 			if !f.TagNegate() && i.GetAssignee() == nil {
 				return false


### PR DESCRIPTION
Although `assigned` tag wasn't documented, I think it's very useful.

In this PR, I fixed below:

- fixed pre-comment fetch rules for `assigned` tag
- add 'assigned' tag in config document