### PR TITLE
Include issue-like comments for PullRequests

### DIFF
--- a/pkg/hubbub/comment.go
+++ b/pkg/hubbub/comment.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hubbub
+
+import (
+	"time"
+
+	"github.com/google/go-github/v31/github"
+)
+
+// GitHubComment is an interface that matches both GitHub issues and pull review comments
+type GitHubComment interface {
+	GetAuthorAssociation() string
+	GetBody() string
+	GetCreatedAt() time.Time
+	GetReactions() *github.Reactions
+	GetHTMLURL() string
+	GetID() int64
+	GetURL() string
+	GetUpdatedAt() time.Time
+	GetUser() *github.User
+	String() string
+}
+
+// Comment is a loose internal comment structure matching issue, PR, code review comments
+type Comment struct {
+	User        *github.User
+	Created     time.Time
+	Updated     time.Time
+	Body        string
+	AuthorAssoc string
+	Reactions   *github.Reactions
+	ReviewID    int64
+}
+
+func NewComment(g GitHubComment) *Comment {
+	return &Comment{
+		User:        g.GetUser(),
+		Body:        g.GetBody(),
+		AuthorAssoc: g.GetAuthorAssociation(),
+		Created:     g.GetCreatedAt(),
+		Updated:     g.GetUpdatedAt(),
+		Reactions:   g.GetReactions(),
+	}
+}

--- a/pkg/hubbub/issue.go
+++ b/pkg/hubbub/issue.go
@@ -172,24 +172,12 @@ func openByDefault(fs []Filter) []Filter {
 	return fs
 }
 
-type CommentLike interface {
-	GetAuthorAssociation() string
-	GetBody() string
-	GetCreatedAt() time.Time
-	GetReactions() *github.Reactions
-	GetHTMLURL() string
-	GetID() int64
-	GetURL() string
-	GetUpdatedAt() time.Time
-	GetUser() *github.User
-	String() string
-}
-
 func (h *Engine) IssueSummary(i *github.Issue, cs []*github.IssueComment) *Conversation {
-	cl := []CommentLike{}
+	cl := []*Comment{}
 	for _, c := range cs {
-		cl = append(cl, CommentLike(c))
+		cl = append(cl, NewComment(c))
 	}
+	
 	co := h.conversation(i, cl)
 	r := i.GetReactions()
 	co.ReactionsTotal += r.GetTotalCount()

--- a/pkg/hubbub/search.go
+++ b/pkg/hubbub/search.go
@@ -268,15 +268,12 @@ func (h *Engine) SearchPullRequests(ctx context.Context, org string, project str
 			continue
 		}
 
-		comments := []*github.PullRequestComment{}
+		var comments []*Comment
 		// pr.GetComments() always returns 0 :(
 		if pr.GetState() == "open" && pr.GetUpdatedAt().After(pr.GetCreatedAt()) {
-			comments, _, err = h.cachedPRComments(ctx, org, project, pr.GetNumber(), pr.GetUpdatedAt())
+			comments, _, err = h.prComments(ctx, org, project, pr.GetNumber(), pr.GetUpdatedAt())
 			if err != nil {
 				klog.Errorf("comments: %v", err)
-			}
-			if pr.GetNumber() == h.debugNumber {
-				klog.Errorf("debug comments: %s", formatStruct(comments))
 			}
 		} else {
 			klog.Infof("skipping comment download for #%d - not updated", pr.GetNumber())


### PR DESCRIPTION
PullRequests have both Code Review comments and Issue comments.

Triage Party has at different points used both, but never at the same time.

Fixes #117