### PR TITLE
display statuses of similar conversations

### DIFF
--- a/pkg/hubbub/similar.go
+++ b/pkg/hubbub/similar.go
@@ -60,6 +60,7 @@ type RelatedConversation struct {
 	Title   string       `json:"title"`
 	Author  *github.User `json:"author"`
 	Type    string       `json:"type"`
+	State   string       `json:"state"`
 	Created time.Time    `json:"created"`
 }
 
@@ -197,6 +198,7 @@ func makeRelated(c *Conversation) *RelatedConversation {
 		Title:   c.Title,
 		Author:  c.Author,
 		Type:    c.Type,
+		State:   c.State,
 		Created: c.Created,
 	}
 }

--- a/site/collection.tmpl
+++ b/site/collection.tmpl
@@ -109,7 +109,7 @@
               <a href="{{ .URL }}" title="{{ .LastCommentBody }}"><strong>{{ .Title }}</strong></a>
               {{ if .Similar }}<div class="similar"><ul>
               {{ range .Similar }}
-                <li><a href="{{ .URL }}" title="Title is similar to #{{ .ID }}">Similar to {{ if eq .Type "pull_request" }}PR{{ end }}#{{ .ID }}: {{ .Title }}</a></li>
+                <li><a href="{{ .URL }}" title="Title is similar to #{{ .ID }}">Similar to {{ if eq .Type "pull_request" }}PR{{ end }}#{{ .ID }}({{ .State }}): {{ .Title }}</a></li>
               {{ end }}
               </div>
               {{ end }}


### PR DESCRIPTION
Displaying similar conversations is a very useful feature!  But we often want to see displayed similar issues/PRs state(is this closed/merged?).  

This PR addresses the issue like below:

![image](https://user-images.githubusercontent.com/608782/83541527-b44c4080-a534-11ea-8e66-b395a0386117.png)

