### PR TITLE
Golangci linting cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ vendor/
 # vim
 *~
 
+#goland
+.idea
+
 # macOS
 .DS_Store
 

--- a/pkg/hubbub/item.go
+++ b/pkg/hubbub/item.go
@@ -193,8 +193,8 @@ func (h *Engine) conversation(i GitHubItem, cs []*Comment, age time.Time) *Conve
 
 	// Loose, but good enough
 	months := time.Since(co.Created).Hours() / 24 / 30
-	co.CommentersPerMonth = float64(co.CommentersTotal) / float64(months)
-	co.ReactionsPerMonth = float64(co.ReactionsTotal) / float64(months)
+	co.CommentersPerMonth = float64(co.CommentersTotal) / months
+	co.ReactionsPerMonth = float64(co.ReactionsTotal) / months
 	return co
 }
 

--- a/pkg/hubbub/pull_requests.go
+++ b/pkg/hubbub/pull_requests.go
@@ -313,7 +313,7 @@ func reviewState(pr GitHubItem, timeline []*github.Timeline, reviews []*github.P
 		return Closed
 	}
 
-	klog.V(1).Infof("PR #%d has %d reviews, hoping one is for %s ...", pr.GetNumber(), (reviews), lastCommitID)
+	klog.V(1).Infof("PR #%d has %d reviews, hoping one is for %s ...", pr.GetNumber(), len(reviews), lastCommitID)
 	lastReview := time.Time{}
 	for _, r := range reviews {
 		if r.GetCommitID() == lastCommitID || lastCommitID == "" {

--- a/pkg/hubbub/similar.go
+++ b/pkg/hubbub/similar.go
@@ -50,7 +50,7 @@ var removeWords = map[string]bool{
 
 // normalize titles for a higher hit-rate
 func normalizeTitle(t string) string {
-	keep := []string{}
+	var keep []string
 	for _, word := range strings.Split(t, " ") {
 		word = nonLetter.ReplaceAllString(word, "")
 		if len(word) == 0 {
@@ -97,7 +97,10 @@ func (h *Engine) updateSimilarityTables(rawTitle, url string) {
 	similarTo := []string{}
 
 	h.titleToURLs.Range(func(k, v interface{}) bool {
-		otherTitle := k.(string)
+		otherTitle, ok := k.(string)
+		if !ok {
+			klog.V(1).Infof("key %q is not of type string", k)
+		}
 		if otherTitle == title {
 			return true
 		}

--- a/pkg/persist/gocache.go
+++ b/pkg/persist/gocache.go
@@ -50,7 +50,10 @@ func newerThanMem(c *cache.Cache, key string, t time.Time) *Thing {
 		return nil
 	}
 
-	th := x.(*Thing)
+	th, ok := x.(*Thing)
+	if !ok {
+		klog.V(1).Infof("%s is not of type Thing", key)
+	}
 
 	if th.Created.Before(t) {
 		klog.V(2).Infof("%s in cache, but %s is older than %s", key, logu.STime(th.Created), logu.STime(t))

--- a/pkg/persist/mem.go
+++ b/pkg/persist/mem.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // Package persist provides a bootstrap for the in-memory cache
-
 package persist
 
 import (

--- a/pkg/triage/github.go
+++ b/pkg/triage/github.go
@@ -45,7 +45,7 @@ func MustReadToken(path string, env string) string {
 		klog.Infof("loaded %d byte github token from %s", len(token), env)
 	}
 
-	token = strings.TrimSpace(string(token))
+	token = strings.TrimSpace(token)
 	if len(token) < 8 {
 		klog.Exitf("github token impossibly small: %q", token)
 	}

--- a/pkg/triage/triage.go
+++ b/pkg/triage/triage.go
@@ -175,7 +175,7 @@ func closedAge(fs []hubbub.Filter) time.Duration {
 
 	if oldest == 0 {
 		klog.Warningf("I need closed data, but I'm not sure how old: picking 4 days")
-		return time.Duration(24 * 4 * time.Hour)
+		return 24 * 4 * time.Hour
 	}
 
 	return oldest


### PR DESCRIPTION
A number of cleanups.  Resisted several which were too opinionated and thought might be contentious.  This resulted in a bug fix around `len(review)`
Fixes:
* remove unnecessary casts
* switch to non `f` formatting func for non formatting strings
* added error handling for non-contentious instances

Things to think about:
1. There are casts out of mysql and postgress wich are not checked 
2. The template.JS(s) is not escaped and likely should change to `JSEscapeString` or place a // no lint comment that it has been evaluated to be ok
3. The `time.Time` return from `cachedIssueComments` and `cachedReviews` is never used
4. cyclomatic complexity is high for `hubbub/item.go:33` and `hubbub/match.go:15`.  These should be refactor IHMO

Signed-off-by: Ken Sipe <kensipe@gmail.com>