### PR TITLE
make comment fetching optional for the initial data cycle

### DIFF
--- a/pkg/hubbub/issue.go
+++ b/pkg/hubbub/issue.go
@@ -107,11 +107,15 @@ func (h *Engine) updateIssues(ctx context.Context, org string, project string, s
 	return allIssues, start, nil
 }
 
-func (h *Engine) cachedIssueComments(ctx context.Context, org string, project string, num int, newerThan time.Time) ([]*github.IssueComment, time.Time, error) {
+func (h *Engine) cachedIssueComments(ctx context.Context, org string, project string, num int, newerThan time.Time, fetch bool) ([]*github.IssueComment, time.Time, error) {
 	key := fmt.Sprintf("%s-%s-%d-issue-comments", org, project, num)
 
 	if x := h.cache.GetNewerThan(key, newerThan); x != nil {
 		return x.IssueComments, x.Created, nil
+	}
+
+	if !fetch {
+		return nil, time.Time{}, nil
 	}
 
 	klog.V(1).Infof("cache miss for %s newer than %s", key, logu.STime(newerThan))

--- a/pkg/hubbub/search.go
+++ b/pkg/hubbub/search.go
@@ -133,7 +133,7 @@ func (h *Engine) SearchIssues(ctx context.Context, org string, project string, f
 
 		if needComments(i, fs) && i.GetComments() > 0 {
 			klog.V(1).Infof("#%d - %q: need comments for final filtering", i.GetNumber(), i.GetTitle())
-			comments, _, err = h.cachedIssueComments(ctx, org, project, i.GetNumber(), h.mtime(i))
+			comments, _, err = h.cachedIssueComments(ctx, org, project, i.GetNumber(), h.mtime(i), !newerThan.IsZero())
 			if err != nil {
 				klog.Errorf("comments: %v", err)
 			}
@@ -283,7 +283,7 @@ func (h *Engine) SearchPullRequests(ctx context.Context, org string, project str
 		var comments []*Comment
 
 		if needComments(pr, fs) {
-			comments, _, err = h.prComments(ctx, org, project, pr.GetNumber(), h.mtime(pr))
+			comments, _, err = h.prComments(ctx, org, project, pr.GetNumber(), h.mtime(pr), !newerThan.IsZero())
 			if err != nil {
 				klog.Errorf("comments: %v", err)
 			}


### PR DESCRIPTION
Start-up optimization for large repositories. Comments will still be used if available.