### PR TITLE
Allow collections to define their own velocity stats

### DIFF
--- a/pkg/hubbub/search.go
+++ b/pkg/hubbub/search.go
@@ -97,7 +97,7 @@ func (h *Engine) SearchIssues(ctx context.Context, org string, project string, f
 		}
 
 		if seen[i.GetURL()] {
-			klog.Errorf("unusual: I already saw #%d", i.GetNumber())
+			klog.Errorf("unusual: I already saw #%d", i.GetURL())
 			continue
 		}
 		seen[i.GetURL()] = true

--- a/pkg/site/page.go
+++ b/pkg/site/page.go
@@ -93,16 +93,20 @@ func (h *Handlers) collectionPage(ctx context.Context, id string, refresh bool) 
 		p.Stale = true
 	}
 
-	for _, s := range sts {
-		if s.UsedForStats {
-			if s.ID == VelocityStatsName {
-				p.VelocityStats = h.updater.Lookup(ctx, s.ID, false)
-				continue
-			}
-			// Older configs may not use OpenStatsName
-			if s.ID == OpenStatsName || p.OpenStats == nil {
-				p.OpenStats = h.updater.Lookup(ctx, s.ID, false)
-				continue
+	if result.Collection.Velocity != "" {
+		p.VelocityStats = h.updater.Lookup(ctx, result.Collection.Velocity, false)
+	} else {
+		for _, s := range sts {
+			if s.UsedForStats {
+				if s.ID == VelocityStatsName {
+					p.VelocityStats = h.updater.Lookup(ctx, s.ID, false)
+					continue
+				}
+				// Older configs may not use OpenStatsName
+				if s.ID == OpenStatsName || p.OpenStats == nil {
+					p.OpenStats = h.updater.Lookup(ctx, s.ID, false)
+					continue
+				}
 			}
 		}
 	}

--- a/pkg/triage/collection.go
+++ b/pkg/triage/collection.go
@@ -37,6 +37,7 @@ type Collection struct {
 	Display  string `yaml:"display"`
 	Overflow int    `yaml:"overflow"`
 	Selector string `yaml:"selector"`
+	Velocity string `yaml:"velocity"`
 }
 
 // The result of Execute


### PR DESCRIPTION
Useful for multi-repository dashboards.