### PR TITLE
Use internal mtime tracking to determine in-memory issue validatity 

### DIFF
--- a/pkg/hubbub/conversation.go
+++ b/pkg/hubbub/conversation.go
@@ -44,7 +44,7 @@ type Conversation struct {
 	// Latest comment or event
 	Updated time.Time `json:"updated"`
 
-	// Seen is the time we last saw this conversation
+	// Seen is the age of the data which generated this data
 	Seen time.Time `json:"seen"`
 
 	// When did this item reach the current priority?

--- a/pkg/hubbub/issue.go
+++ b/pkg/hubbub/issue.go
@@ -215,10 +215,10 @@ func (h *Engine) IssueSummary(i *github.Issue, cs []*github.IssueComment, age ti
 	key := i.GetHTMLURL()
 	cached, ok := h.seen[key]
 	if ok {
-		if !cached.Updated.Before(i.GetUpdatedAt()) && cached.CommentsTotal >= len(cs) {
+		if !cached.Seen.Before(h.mtime(i)) && cached.CommentsTotal >= len(cs) {
 			return h.seen[key]
 		}
-		klog.Infof("%s in issue cache, but was invalid. Live @ %s (%d comments), cached @ %s (%d comments)  ", i.GetHTMLURL(), i.GetUpdatedAt(), len(cs), cached.Updated, cached.CommentsTotal)
+		klog.Infof("%s in issue cache, but was invalid. Live @ %s (%d comments), cached @ %s (%d comments)  ", i.GetHTMLURL(), h.mtime(i), len(cs), cached.Seen, cached.CommentsTotal)
 	}
 
 	h.seen[key] = h.createIssueSummary(i, cs, age)

--- a/pkg/hubbub/pull_requests.go
+++ b/pkg/hubbub/pull_requests.go
@@ -290,10 +290,10 @@ func (h *Engine) PRSummary(ctx context.Context, pr *github.PullRequest, cs []*Co
 	key := pr.GetHTMLURL()
 	cached, ok := h.seen[key]
 	if ok {
-		if !cached.Updated.Before(pr.GetUpdatedAt()) && cached.CommentsTotal >= len(cs) && cached.TimelineTotal >= len(timeline) && cached.ReviewsTotal >= len(reviews) {
+		if !cached.Seen.Before(h.mtime(pr)) && cached.CommentsTotal >= len(cs) && cached.TimelineTotal >= len(timeline) && cached.ReviewsTotal >= len(reviews) {
 			return h.seen[key]
 		}
-		klog.Infof("%s in PR cache, but was invalid. Live @ %s (%d comments), cached @ %s (%d comments)  ", pr.GetHTMLURL(), pr.GetUpdatedAt(), len(cs), cached.Updated, cached.CommentsTotal)
+		klog.Infof("%s in PR cache, but was invalid. Live @ %s (%d comments), cached @ %s (%d comments)  ", pr.GetHTMLURL(), h.mtime(pr), len(cs), cached.Seen, cached.CommentsTotal)
 	}
 
 	h.seen[key] = h.createPRSummary(ctx, pr, cs, timeline, reviews, age, fetch)


### PR DESCRIPTION
Fixes issue where we caching issue data in memory for too long, as we were relying on GitHub's authoritative issue update time which does not include reference updates.