### PR TITLE
Prevent endless loop of loading same page

### DIFF
--- a/pkg/hubbub/pull_requests.go
+++ b/pkg/hubbub/pull_requests.go
@@ -110,7 +110,7 @@ func (h *Engine) updatePRs(ctx context.Context, sp provider.SearchParams) ([]*pr
 
 		go h.updateSimilarPullRequests(sp.SearchKey, prs)
 
-		if resp.NextPage == 0 || foundOldest {
+		if resp.NextPage == 0 || resp.NextPage == sp.PullRequestListOptions.Page || foundOldest {
 			break
 		}
 		sp.PullRequestListOptions.Page = resp.NextPage

--- a/pkg/hubbub/timeline.go
+++ b/pkg/hubbub/timeline.go
@@ -61,7 +61,7 @@ func (h *Engine) updateTimeline(ctx context.Context, sp provider.SearchParams) (
 		}
 
 		allEvents = append(allEvents, evs...)
-		if resp.NextPage == 0 {
+		if resp.NextPage == 0 || sp.ListOptions.Page == resp.NextPage {
 			break
 		}
 		sp.ListOptions.Page = resp.NextPage


### PR DESCRIPTION
When loading up rocketchat/rocket.chat here on github it entered two different endless loops looking at the same page repeatedly.  With the addition of these two checks it now loads the entire history successfully.

closes #213 