### PR TITLE
Build application on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+---
+name: CI Build
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['master']
+
+jobs:
+  docker:
+    name: "Build app"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build --tag=tp .


### PR DESCRIPTION
Hello,

@tstromberg  propose that we can run integration tests on Github Action (https://github.com/google/triage-party/issues/215), but I think it is also worth doing a basic CI check also - try to compile the applications.  The compiler can detect many problems without human intervention. 

In next changes, I will try to introduce other tests that will check the quality of the code and compliance with good practices and Google recommendations.

Best regards,
Kamil Breguła
