### PR TITLE
Tweak UI styling

### DIFF
--- a/site/base.tmpl
+++ b/site/base.tmpl
@@ -10,7 +10,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ block "title" .}} {{end}} :: Triage Party</title>
-    <link rel="stylesheet" href="/third_party/bulma/bulma.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
     <link rel="stylesheet" href="/third_party/fontawesome/css/all.min.css">
     <link rel="stylesheet" href="/static/css/tparty.css?{{.Version}}">
     {{ block "style" .}} {{end}}

--- a/site/collection.tmpl
+++ b/site/collection.tmpl
@@ -3,7 +3,6 @@
 {{ end }}
 
 {{ define "style" }}
-  <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.19/css/jquery.dataTables.css">
   <link rel="stylesheet" href="/third_party/datatables-bulma/dataTables.bulma.css" />
 {{ end }}
 
@@ -62,14 +61,14 @@
 
   {{ if .CollectionResult.RuleResults }}
     {{ if ne .Description "" }}
-      <div class="box description">
+      <div class="panel description">
       <pre>{{ .Description }}</pre>
       </div>
     {{ end }}
 
     {{ range .CollectionResult.RuleResults }}
       {{ if eq (len .Items) 0 }}
-        <div class="no-matches" title="{{ .Rule | toYAML }}"><strong>{{ .Rule.Name }}</strong>: No matching items</div>
+        <div class="panel no-matches" title="{{ .Rule | toYAML }}"><strong>{{ .Rule.Name }}</strong>: No matching items</div>
       {{ else }}
         <script>
         function {{ .Rule.ID | toJSfunc }}tabs() {
@@ -77,19 +76,22 @@
             {{ end }}
         }
         </script>
-        <div class="box outcome">
-        <div class="box-header collapsible">
+        <div class="panel outcome">
+        <div class="panel-heading collapsible">
           <div class="box-head-left">
-            <h3 title="{{ .Rule | toYAML }}">{{ .Rule.Name }} ({{ len .Items }})<div class="tab-link"><a href="#" title="open in new tabs" onclick="{{ .Rule.ID | toJSfunc }}tabs(); return false;"><i class="fas fa-external-link-alt"></i></a></div></h3>
-            <h4 class="subtitle">Resolution: {{ .Rule.Resolution }}</h4>
-            <h5 class="stats">Average age: {{ .AvgAge | toDays }}, Avg wait: {{ .AvgCurrentHold | toDays }}</h5>
+            <h3 class="title" title="{{ .Rule | toYAML }}">{{ .Rule.Name }} ({{ len .Items }})<div class="tab-link"><a href="#" title="open in new tabs" onclick="{{ .Rule.ID | toJSfunc }}tabs(); return false;"><i class="fas fa-external-link-alt"></i></a></div></h3>
+            <div class="subtitle is-size-6">
+              <div>Resolution: {{ .Rule.Resolution }}</div>
+              <div>Average age: {{ .AvgAge | toDays }}, Avg wait: {{ .AvgCurrentHold | toDays }}</div>
+            </div>
           </div>
           <div class="box-head-right">
           <!--  just save the space -->
           </div>
         </div>
-        <table id="{{ .Rule.ID | toJSfunc  }}" class="compact is-size-6">
-        <thead>
+        <div class="panel-block">
+        <table id="{{ .Rule.ID | toJSfunc  }}" class="table is-hoverable">
+        <thead class="is-size-7">
           <tr>
             <td class="hd col-id">ID</td>
             <td class="hd col-author" title="Author">Au</td>
@@ -114,7 +116,7 @@
               <td class="cell-id"><a href="{{ .URL }}">{{ .ID }}</a></td>
               <td class="cell-author" data-order="{{ .Author.GetLogin }}">{{ .Author | Avatar }}</td>
               <td class="cell-desc">
-                <a href="{{ .URL }}" title="@{{ .LastCommentAuthor.GetLogin}}: {{ .LastCommentBody }}"><strong>{{ .Title }}</strong></a>
+                <a href="{{ .URL }}" title="@{{ .LastCommentAuthor.GetLogin}}: {{ .LastCommentBody }}">{{ .Title }}</a>
 
                 {{ if .PullRequestRefs }}
                   <ul class="pull-requests">
@@ -155,12 +157,16 @@
               <td class="cell-response" data-order="{{ .LatestMemberResponse | UnixNano }}">{{ .LatestMemberResponse | RoughTime }}</td>
               <td class="cell-comments" data-order="{{ .CommentersTotal }}">{{ range .Commenters }}{{ . |  Avatar}}{{ end }}</td>
               <td class="cell-labels">
+                <div class="tags">
                 {{ range .Labels }}
-                  <div class="gh-label" style="background-color: #{{ .Color }}; color: #{{ .Color | TextColor }};">{{ .Name }}</div>
+                  <div class="tag" style="background-color: #{{ .Color }}; color: #{{ .Color | TextColor }};">{{ .Name }}</div>
                 {{ end }}
+                </div>
               </td>
               <td class="cell-tags">
-                {{ range $k, $_ := .Tags }}<div class="gh-tag tag-{{ $k.ID }}" title="{{ $k.Desc }}">{{ $k.ID }}</div> {{ end }}
+                <div class="tags">
+                {{ range $k, $_ := .Tags }}<div class="tag tag-{{ $k.ID }}" title="{{ $k.Desc }}">{{ $k.ID }}</div> {{ end }}
+                </div>
               </td>
             </tr>
             {{ end }}
@@ -178,6 +184,7 @@
           {{ end }}
         </tbody>
         </table>
+        </div>
         </div>
       {{ end }}
     {{ end }}

--- a/site/kanban.tmpl
+++ b/site/kanban.tmpl
@@ -3,7 +3,6 @@
 {{ end }}
 
 {{ define "style" }}
-  <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.19/css/jquery.dataTables.css">
   <link rel="stylesheet" href="/third_party/datatables-bulma/dataTables.bulma.css" />
   <link rel="stylesheet" href="/static/css/kanban.css?{{.Version}}">
 {{ end }}
@@ -55,19 +54,20 @@
   {{ if .CollectionResult.RuleResults }}
 
     {{ if ne .Description "" }}
-      <div class="box description">
+      <div class="panel description">
       <pre>{{ .Description }}</pre>
       </div>
     {{ end }}
 
-    <div class="box outcome kanban">
-        <div class="box-header collapsible">
+    <div class="panel outcome kanban">
+        <div class="panel-heading collapsible">
           <div class="box-head-left">
             {{ if .Milestone }}
-              <h3>{{ .Title }}: {{ .Milestone.Title }}</h3>
-              <h4 class="subtitle">Due: {{ if .Milestone.DueOn }}{{ .Milestone.DueOn.Format "2006-01-02" }} ({{.Milestone.DueOn | RoughTime }}){{ else }}Never{{ end }}</h4>
+              <h3 class="title">{{ .Title }}: {{ .Milestone.Title }}</h3>
+              <div class="subtitle is-size-6">
+                <div>Due: {{ if .Milestone.DueOn }}{{ .Milestone.DueOn.Format "2006-01-02" }} ({{.Milestone.DueOn | RoughTime }}){{ else }}Never{{ end }}</div>
                 {{ if not .MilestoneETA.IsZero }}
-                  <h4 class="subtitle {{ if .MilestoneVeryLate}}very-late-eta{{ else if gt .MilestoneCountOffset 0}}late-eta{{ else if lt .MilestoneCountOffset 0}}early-eta{{ end }}">Completion ETA:
+                  <div class="{{ if .MilestoneVeryLate}}very-late-eta{{ else if gt .MilestoneCountOffset 0}}late-eta{{ else if lt .MilestoneCountOffset 0}}early-eta{{ end }}">Completion ETA:
                       <span class="eta">
                           {{ .MilestoneETA.Format "~2006-01-02" }}
                           {{ if .Milestone.DueOn }}
@@ -77,27 +77,31 @@
                             {{ end }}
                           {{ end }}
                       </span>
-                  </h4>
+                  </div>
                 {{ end }}
-                <h5 class="stats">{{ .Milestone.GetOpenIssues}} open issues, {{ .Milestone.GetClosedIssues }} closed issues</h5>
+                <div>{{ .Milestone.GetOpenIssues}} open issues, {{ .Milestone.GetClosedIssues }} closed issues</div>
+              </div>
             {{ else }}
               <h3>{{ .Title }}</h3>
-              <h5 class="stats">{{ .Total }} unique items</h5>
-              {{ if not .CompletionETA.IsZero }}
-                <h4 class="subtitle">Completion ETA:
-                    <span class="eta">
-                        {{ .CompletionETA.Format "~2006-01-02" }}
-                    </span>
-                </h4>
-              {{ end }}
+              <div class="subtitle is-size-6">
+                <div>{{ .Total }} unique items</div>
+                {{ if not .CompletionETA.IsZero }}
+                  <div>Completion ETA:
+                      <span class="eta">
+                          {{ .CompletionETA.Format "~2006-01-02" }}
+                      </span>
+                  </div>
+                {{ end }}
+              </div>
             {{ end }}
           </div>
           <div class="box-head-right">
           <!--  just save the space -->
           </div>
         </div>
+        <div class="panel-block">
         <table id="kanban-table" class="compact is-size-6">
-      <thead>
+        <thead class="is-size-7">
         <tr>
           <th class="hd" id="assignee-col">Assi</th>
           {{- range .CollectionResult.RuleResults }}
@@ -141,7 +145,7 @@
 
                 <ul class="refs">
                     {{ range .PullRequestRefs }}
-                      <li class="tag-default tag-pr-{{.ReviewState | Class }}"><a href="{{ .URL }}" title='"{{ .Title }}" by @{{.Author.GetLogin}} ({{.ReviewState}})'>{{ .ID }}</li>
+                      <li class="tag tag-default tag-pr-{{.ReviewState | Class }}"><a href="{{ .URL }}" title='"{{ .Title }}" by @{{.Author.GetLogin}} ({{.ReviewState}})'>{{ .ID }}</li>
                     {{ end }}
                 </ul>
               </div>
@@ -152,6 +156,7 @@
       </tr>
       {{ end }}
       </table>
+      </div>
   {{ end }}
 {{ end }} 
 

--- a/site/static/css/kanban.css
+++ b/site/static/css/kanban.css
@@ -1,4 +1,3 @@
-
 /**
  * Copyright 2020 Google LLC
  *
@@ -15,9 +14,9 @@
  * limitations under the License.
  */
 
- th {
+/* th {
   color: #fff !important;
-}
+} */
 
 .sticky {
   background-color: #ffc;
@@ -25,7 +24,7 @@
 
   padding: 0.6em;
   margin: 0.4em;
-  
+
   clear: right;
   float: left;
   width: 10em;
@@ -60,22 +59,20 @@
   display: inline !important;
 }
 
-
 /* sticky colors based on GitHub labels! */
 .kind-process {
-  background-color: #A5FF8F;
-  border: 1px solid #85DF6F;
+  background-color: #a5ff8f;
+  border: 1px solid #85df6f;
 }
 
 .kind-bug {
-  background-color: #FDBABC;
-  border: 1px solid #DD9A9C;
+  background-color: #fdbabc;
+  border: 1px solid #dd9a9c;
 }
 
-
 .kind-documentation {
-  background-color: #A0F2FF;
-  border: 1px solid #80D2DF;
+  background-color: #a0f2ff;
+  border: 1px solid #80d2df;
 }
 
 .prority-urgent {
@@ -84,7 +81,7 @@
 
 .sticky-overflow {
   background-color: #999;
-  border: 1px solid #99F;
+  border: 1px solid #99f;
   font-style: italic;
   font-size: 90%;
   color: #333;
@@ -116,16 +113,16 @@
 }
 
 .unassigned-lane .sticky {
- box-shadow: 2px 2px 8px #333;
-}  
+  box-shadow: 2px 2px 8px #333;
+}
 
 .late-eta {
-  color: #FF0 !important;
+  color: #ff0 !important;
   font-weight: bold !important;
 }
 
 .very-late-eta {
-  color: #FB54A3 !important;
+  color: #fb54a3 !important;
   font-weight: bold !important;
   font-size: 90% !important;
 }
@@ -140,12 +137,11 @@
 }
 
 .refs li {
-  border: 1px solid rgba(0, 0, 0, .2);
+  border: 1px solid rgba(0, 0, 0, 0.2);
   padding-left: 0.3em;
   padding-right: 0.3em;
   display: inline-block;
   word-wrap: break-word;
   font-size: smaller;
-  background-color: #FFF;
+  background-color: #fff;
 }
-

--- a/site/static/css/tparty.css
+++ b/site/static/css/tparty.css
@@ -25,35 +25,17 @@ Vivid and Sharp: https://visme.co/blog/website-color-schemes/
 #A4B3B6 - greyish
 */
 
-body {
-  background-color: #E4F3F6;
+a {
+  color: #44318d;
 }
 
-.box {
-  padding: 0;
-  border: 1px solid #d9b8ee;
-  border-radius: 0;
+.title {
+  font-weight: 300;
 }
 
 .navbar-item img {
   max-height: 1.25rem;
   margin-left: 0.25rem;
-}
-
-.box-header {
-  background-color: #44318D;
-  color: #FFF;
-  font-weight: bold;
-  padding-left: 0.7rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}
-
-.dataTables_filter label {
-  display: inline-block;
-  color: #A4B386;
-  padding-top: 0.5rem;
-  padding-right: 1rem;
 }
 
 .columns {
@@ -72,43 +54,19 @@ body {
   margin-top: -3.25rem !important;
 }
 
-.dataTable {
-  width: 100% !important;
-}
-
 .column {
   padding: 0;
 }
-
-h1.title {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-h3 {
-  font-weight: bold;
-}
-
-h4.subtitle {
-  color: #fff;  
-  font-size: small;
-  margin-bottom: 0 !important;  
-}
-h5.stats {
-  color: #fff;  
-  font-size: small;
-}
-
 
 a.navbar-item {
   color: #fff;
 }
 
 .play-fast-back {
-  color: #A4B3B6;
+  color: #a4b3b6;
 }
 .play-fast-forward {
-  color: #A4B3B6;
+  color: #a4b3b6;
 }
 
 nav {
@@ -118,11 +76,10 @@ nav {
 nav.secondary {
   height: 2rem;
   min-height: 2rem;
-  max-height:2rem;
+  max-height: 2rem;
   padding: 0.2rem;
   padding-right: 0.8em;
 }
-
 
 .navbar-center {
   margin-left: auto;
@@ -143,139 +100,102 @@ nav.secondary {
   padding-right: 0.5rem;
 }
 
-table.is-size-6 {
-  font-size: 0.9rem !important;
-  width: 100%;
-}
-
-thead {
-  color: #fff;
- }
-
 .navbar {
-  color: #F0F0F0;
-  background-color: #C82F77;
+  color: #f0f0f0;
+  background-color: #c82f77;
 }
 
 .secondary {
-  background-color: #2A1B3D;
-  color: #FFF;
+  background-color: #2a1b3d;
+  color: #fff;
 }
 
-thead {
-  background-color: #7D68A3;
-}
-
-.hd {
-  border-right: 1px dashed #5D4883;
-  padding-left: 0.5em !important;
-}
-
-.hd:last-child {
-  border-right: none;
-}
-
-td { padding: 0.2rem !important; }
-td:first-child { padding-left: 0.4em !important; }
-td:last-child { padding-right: 0.2em !important; }
-
-.gh-label {
-  border-radius: 2px;
-  box-shadow: inset 0 -1px 0 rgba(27,31,35,.12);
-  font-size: 0.75rem; 
-  font-weight: 600;
-  padding: 0px 4px;
-  display: inline-block;
-}
-
-.gh-tag {
-  border-radius: 2px;
-  box-shadow: inset 0 -1px 0 rgba(27,31,35,.12);
-  background-color: #e0e0e0;
-  font-weight: 600;
-  font-size: 0.75rem; 
-  padding: 0px 4px;
-  display: inline-block;
-  color: #000;
-}
-
-.tag-default {
+.outcome .tag-default {
   background-color: #e0e0e0;
 }
 
-.tag-send {
+.outcome .tag-send {
   background-color: #0f0;
 }
-.tag-recv {
-  background-color: #F83F87;
+.outcome .tag-recv {
+  background-color: #f83f87;
 }
-.tag-a-has-q {
-  background-color: #E98074;
-}
-
-
-.tag-pr-unreviewed, .tag-unreviewed {
-  background-color: #F08 !important;
-  color: #FFF !important;
-  font-weight: bold;
-  font-style: italic;
- 
+.outcome .tag-a-has-q {
+  background-color: #e98074;
 }
 
-.tag-pr-unreviewed a {
-  color: #FFF !important;
-}
-
-.tag-pr-new-commits,.tag-new-commits {
-  background-color: #F80 !important;    
-  color: #FFF !important;
+.outcome .tag-pr-unreviewed,
+.outcome .tag-unreviewed {
+  background-color: #f08 !important;
+  color: #fff !important;
   font-weight: bold;
   font-style: italic;
 }
 
-.tag-pr-new-commits a {
-  color: #FFF !important;
+.outcome .tag-pr-unreviewed a {
+  color: #fff !important;
 }
 
-.tag-pr-approved,.tag-approved {
-  background-color: #00A125 !important;
-  color: #FFF !important;
-}
-.tag-pr-pushed-after-approval,.tag-pushed-after-approval {
-  background-color: #80A125 !important;
-  color: #FFF !important;
-}
-
-.tag-pr-approved a {
-  color: #FFF !important;  
+.outcome .tag-pr-new-commits,
+.outcome .tag-new-commits {
+  background-color: #f80 !important;
+  color: #fff !important;
+  font-weight: bold;
+  font-style: italic;
 }
 
-.tag-pr-merged,.tag-merged {
-  background-color: #6418BD !important;
-  color: #FFF !important;
+.outcome .tag-pr-new-commits a {
+  color: #fff !important;
 }
 
-.tag-pr-merged a {
-  color: #FFF !important;
+.outcome .tag-pr-approved,
+.outcome .tag-approved {
+  background-color: #00a125 !important;
+  color: #fff !important;
+}
+.outcome .tag-pr-pushed-after-approval,
+.outcome .tag-pushed-after-approval {
+  background-color: #80a125 !important;
+  color: #fff !important;
 }
 
-.tag-pr-closed,.tag-closed {
-  background-color: #CA2339 !important;
-  color: #000 !important;  
+.outcome .tag-pr-approved a {
+  color: #fff !important;
+}
+
+.outcome .tag-pr-merged,
+.outcome .tag-merged {
+  background-color: #6418bd !important;
+  color: #fff !important;
+}
+
+.outcome .tag-pr-merged a {
+  color: #fff !important;
+}
+
+.outcome .tag-pr-closed,
+.outcome .tag-closed {
+  background-color: #ca2339 !important;
+  color: #000 !important;
   text-decoration: line-through;
 }
 
-.tag-pr-closed a {
+.outcome .tag-pr-closed a {
   color: #000 !important;
 }
 
-.tag-pr-changes-requested, .tag-changes-requested {
-  background-color: #FF0 !important;
+.outcome .tag-pr-changes-requested,
+.outcome .tag-changes-requested {
+  background-color: #ff0 !important;
+}
+
+.tags .tag {
+  margin-bottom: 0.25rem;
 }
 
 /* Fix bulma datatables funkiness */
 .sorting_asc {
-  background-color: #6D5893;
+  font-weight: bold;
 }
 
 .sorting_asc::after {
@@ -283,12 +203,12 @@ td:last-child { padding-right: 0.2em !important; }
 }
 
 .sorting_desc {
-  background-color: #8D78B3;
+  font-weight: bold;
 }
 
 .sorting_desc::after {
   content: "" !important;
-} 
+}
 
 .sorting::after {
   content: "" !important;
@@ -326,17 +246,32 @@ td:last-child { padding-right: 0.2em !important; }
 .cell-author {
   width: 2.3em;
 }
+
+.cell-author img,
+.cell-assignee img,
+.cell-comments img {
+  opacity: 0.75;
+  border-radius: 2px;
+}
+
+tr:hover .cell-author img,
+tr:hover .cell-assignee img,
+tr:hover .cell-comments img {
+  opacity: 1;
+}
+
 .cell-id {
   width: 3em;
+  font-size: small;
 }
 
 .similar {
-  background-color: #FFFDE9;
+  background-color: #fffde9;
   font-size: small;
   color: #000;
   margin: 0.3rem;
   padding: 0.3rem;
-  border: 1px dashed #C9CAAB;
+  border: 1px dashed #c9caab;
 }
 
 .dupes {
@@ -344,7 +279,7 @@ td:last-child { padding-right: 0.2em !important; }
 }
 
 .similar a {
-  color: #3F1D09;
+  color: #3f1d09;
 }
 
 .section {
@@ -358,12 +293,8 @@ td:last-child { padding-right: 0.2em !important; }
 
 .is-active {
   font-weight: bold;
-  color: #FFF !important;
-  background-color: #D83F87 !important;
-}
-
-.even {
-  background-color: #F7F7F7 !important;
+  color: #fff !important;
+  background-color: #d83f87 !important;
 }
 
 .reaction-heart:before {
@@ -403,7 +334,7 @@ td:last-child { padding-right: 0.2em !important; }
 }
 
 .no-matches {
-  background-color: #CEE0E3;
+  border-left: 0.5rem solid #cee0e3;
   margin-bottom: 1em;
   padding: 0.5em;
   max-width: 50%;
@@ -418,12 +349,12 @@ td:last-child { padding-right: 0.2em !important; }
 .alt-view {
   margin-left: 0.8em;
   padding-left: 0.8em;
-  border-left: 1px dashed #5A35FF;  
+  border-left: 1px dashed #5a35ff;
 }
 
 .alt-view a {
   color: #fff;
-  text-decoration: underline;  
+  text-decoration: underline;
 }
 
 .pull-requests {
@@ -434,4 +365,8 @@ td:last-child { padding-right: 0.2em !important; }
 
 .description pre {
   padding: 0.8rem;
+}
+
+.outcome {
+  border-left: 0.5rem solid #44318d;
 }


### PR DESCRIPTION
I find the existing UI hard to read. It's good at showing a lot info at high density, but I find that distracting when going through issues (sometimes even via screen sharing). I propose a lighter touch, less dense and more readable. 

- keep main color theme based on Vivid and Sharp: https://visme.co/blog/website-color-schemes/
- remove lots of custom styles and embrace Bulma panel and table styles
- updates Bulma from 0.75 to 0.9
- remove datatable-specific styling

Before: 
![Screenshot 2020-11-06 at 14 53 05](https://user-images.githubusercontent.com/859729/98373789-0e9b8100-2040-11eb-82e6-880d8e5f5a2c.png)

After:
![Screenshot 2020-11-06 at 14 52 30](https://user-images.githubusercontent.com/859729/98373804-12c79e80-2040-11eb-9883-801cee048e65.png)

