### PR TITLE
Validate configured repos

### DIFF
--- a/pkg/triage/triage.go
+++ b/pkg/triage/triage.go
@@ -218,6 +218,22 @@ func (p *Party) validateLoadedConfig() error {
 		return fmt.Errorf("No 'filters' found in the configuration")
 	}
 
+	// validate that requested repos map to known providers
+	repos := p.settings.Repos
+	if len(p.reposOverride) > 0 {
+		repos = p.reposOverride
+	}
+
+	for _, repo := range repos {
+		r, err := parseRepo(repo)
+		if err != nil {
+			return fmt.Errorf("invalid repo URL %q", repo)
+		}
+		if provider.ResolveProviderByHost(r.Host) == nil {
+			return fmt.Errorf("unknown provider host %q", r.Host)
+		}
+	}
+
 	klog.Infof("configuration defines %d filters - looking good!", filters)
 	return nil
 }


### PR DESCRIPTION
Currently if a repo name cannot be parsed or has no provider, a panic will result, e.g.:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x178990f]

goroutine 40 [running]:
github.com/google/triage-party/pkg/hubbub.(*Engine).updateIssues(0xc000440b40, 0x1b12ec0, 0xc00003c098, 0x7ffeefbff707, 0x1, 0x7ffeefbff709, 0x1, 0x7ffeefbff6ff, 0x7, 0x0, ...)
	/Users/kalafut/dev/triage-party/pkg/hubbub/issue.go:87 +0x4ef
github.com/google/triage-party/pkg/hubbub.(*Engine).cachedIssues(0xc000440b40, 0x1b12ec0, 0xc00003c098, 0x7ffeefbff707, 0x1, 0x7ffeefbff709, 0x1, 0x7ffeefbff6ff, 0x7, 0x0, ...)
	/Users/kalafut/dev/triage-party/pkg/hubbub/issue.go:46 +0x378
github.com/google/triage-party/pkg/hubbub.(*Engine).SearchIssues.func1(0xc000592580, 0xc0000c8d80, 0xc000440b40, 0x1b12ec0, 0xc00003c098, 0xc000693440, 0xc000693400)
	/Users/kalafut/dev/triage-party/pkg/hubbub/search.go:66 +0x178
created by github.com/google/triage-party/pkg/hubbub.(*Engine).SearchIssues
	/Users/kalafut/dev/triage-party/pkg/hubbub/search.go:58 +0x438
```


This PR validates all URLs as soon as the config is loaded and will return a nicer error:

```
F1113 15:04:03.690167   53505 main.go:129] load from config.yaml: validate config: unknown provider host "abc.com"
```