### PR TITLE
Avoid panics due to Github and Gitlab API error results

### DIFF
--- a/pkg/provider/github.go
+++ b/pkg/provider/github.go
@@ -55,6 +55,9 @@ func (p *GithubProvider) getRate(i *github.Rate) Rate {
 }
 
 func (p *GithubProvider) getResponse(i *github.Response) *Response {
+	if i == nil {
+		return nil
+	}
 	r := Response{
 		NextPage:      i.NextPage,
 		PrevPage:      i.PrevPage,

--- a/pkg/provider/github_test.go
+++ b/pkg/provider/github_test.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestGithub_GetResponse(t *testing.T) {
+	p := GithubProvider{}
+	p.getResponse(nil)
+}
+
+func TestGithub_GetIssues(t *testing.T) {
+	p := GithubProvider{}
+	p.getIssues(nil)
+}
+
+func TestGithub_GetIssueComments(t *testing.T) {
+	p := GithubProvider{}
+	p.getIssueComments(nil)
+}
+
+func TestGithub_GetIssueTimeline(t *testing.T) {
+	p := GithubProvider{}
+	p.getIssueTimeline(nil)
+}
+
+func TestGithub_GetPullRequestsList(t *testing.T) {
+	p := GithubProvider{}
+	p.getPullRequestsList(nil)
+}
+
+func TestGithub_GetPullRequest(t *testing.T) {
+	p := GithubProvider{}
+	p.getPullRequest(nil)
+}
+
+func TestGithub_GetPullRequestListComments(t *testing.T) {
+	p := GithubProvider{}
+	p.getPullRequestListComments(nil)
+}
+
+func TestGithub_GetPullRequestsListReviews(t *testing.T) {
+	p := GithubProvider{}
+	p.getPullRequestsListReviews(nil)
+}

--- a/pkg/provider/gitlab.go
+++ b/pkg/provider/gitlab.go
@@ -121,6 +121,9 @@ func (p *GitlabProvider) getRate(i *gitlab.Response) Rate {
 }
 
 func (p *GitlabProvider) getResponse(i *gitlab.Response) *Response {
+	if i == nil {
+		return nil
+	}
 	r := Response{
 		NextPage: i.NextPage,
 		Rate:     p.getRate(i),
@@ -252,6 +255,9 @@ func (p *GitlabProvider) getMilestone(i *gitlab.Milestone) *Milestone {
 }
 
 func (p *GitlabProvider) getPullRequest(v *gitlab.MergeRequest) *PullRequest {
+	if v == nil {
+		return nil
+	}
 	id := int64(v.ID)
 	m := &PullRequest{
 		Assignee:  p.getUserFromBasicUser(v.Assignee, true),
@@ -323,6 +329,9 @@ func (p *GitlabProvider) PullRequestsListComments(ctx context.Context, sp Search
 }
 
 func (p *GitlabProvider) getPullRequestReviews(i *gitlab.MergeRequestApprovals) []*PullRequestReview {
+	if i == nil {
+		return nil
+	}
 	r := make([]*PullRequestReview, len(i.ApprovedBy))
 	state := "APPROVED"
 	for k, v := range i.ApprovedBy {

--- a/pkg/provider/gitlab_test.go
+++ b/pkg/provider/gitlab_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestGitlab_GetResponse(t *testing.T) {
+	p := GitlabProvider{}
+	p.getResponse(nil)
+}
+
+func TestGitlab_GetIssues(t *testing.T) {
+	p := GitlabProvider{}
+	p.getIssues(nil)
+}
+
+func TestGitlab_GetIssueComments(t *testing.T) {
+	p := GitlabProvider{}
+	p.getIssueComments(nil)
+}
+
+func TestGitlab_GetPullRequests(t *testing.T) {
+	p := GitlabProvider{}
+	p.getPullRequests(nil)
+}
+
+func TestGitlab_GetPullRequest(t *testing.T) {
+	p := GitlabProvider{}
+	p.getPullRequest(nil)
+}
+
+func TestGitlab_GetPullRequestComments(t *testing.T) {
+	p := GitlabProvider{}
+	p.getPullRequestComments(nil)
+}
+
+func TestGitlab_GetPullRequestReviews(t *testing.T) {
+	p := GitlabProvider{}
+	p.getPullRequestReviews(nil)
+}


### PR DESCRIPTION
Fixed #236 by changing the Github and Gitlab providers to handle nil responses from the API layers.  Adds very superficial tests — better than nothing!