### PR TITLE
Use name parameter from settings file if present

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -140,9 +140,14 @@ func main() {
 	}
 
 	klog.Infof("Loaded %d rules", len(ts))
+
+	// Establish site name based on the first available
+	// of: CLI parameter, settings file, or default from repo names.
 	sn := *siteName
 	if sn == "" {
-		sn = calculateSiteName(ts)
+		if sn = tp.Name(); sn == "" {
+			sn = calculateSiteName(ts)
+		}
 	}
 
 	u := updater.New(updater.Config{

--- a/pkg/triage/triage.go
+++ b/pkg/triage/triage.go
@@ -342,3 +342,8 @@ func processRules(raw map[string]Rule) (map[string]Rule, error) {
 func (p *Party) ConversationsTotal() int {
 	return p.engine.ConversationsTotal()
 }
+
+// Name returns the configured site name
+func (p *Party) Name() string {
+	return p.settings.Name
+}


### PR DESCRIPTION
The top-level [name](https://github.com/google/triage-party/blob/master/docs/config.md#settings) parameter does not affect the site name as claimed in the docs. This PR will use the setting if present, unless the CLI  `-name` parameter is set, which will take precedence.