### PR TITLE
Fix a bug listing pull requests

### DIFF
--- a/pkg/provider/filter.go
+++ b/pkg/provider/filter.go
@@ -55,7 +55,7 @@ type Filter struct {
 	State              string `yaml:"state,omitempty"`
 }
 
-// LoadLabelRegex loads a new label reegx
+// LoadLabelRegex loads a new label regex
 func (f *Filter) LoadLabelRegex() error {
 	label, negateLabel := negativeMatch(f.RawLabel)
 

--- a/pkg/provider/github.go
+++ b/pkg/provider/github.go
@@ -159,7 +159,7 @@ func (p *GitHubProvider) IssuesListIssueTimeline(ctx context.Context, sp SearchP
 
 func (p *GitHubProvider) getPullRequestsListOptions(sp SearchParams) *github.PullRequestListOptions {
 	return &github.PullRequestListOptions{
-		ListOptions: p.getListOptions(sp.IssueListCommentsOptions.ListOptions),
+		ListOptions: p.getListOptions(sp.PullRequestListOptions.ListOptions),
 		State:       sp.PullRequestListOptions.State,
 		Sort:        sp.PullRequestListOptions.Sort,
 		Direction:   sp.PullRequestListOptions.Direction,


### PR DESCRIPTION
We were using the wrong set of list options when listing pull requests. This lead to only listing the first page of pull requests.

I also found and fixed a typo.