### PR TITLE
Add author filter

### DIFF
--- a/pkg/hubbub/match.go
+++ b/pkg/hubbub/match.go
@@ -78,6 +78,13 @@ func preFetchMatch(i provider.IItem, labels []*provider.Label, fs []provider.Fil
 			}
 		}
 
+		if f.AuthorRegex() != nil {
+			if ok := matchNegateRegex(*i.GetUser().Login, f.AuthorRegex(), f.AuthorNegate()); !ok {
+				klog.V(2).Infof("#%d author does not meet %s", i.GetNumber(), f.AuthorRegex())
+				return false
+			}
+		}
+
 		if f.LabelRegex() != nil {
 			if ok := matchLabel(labels, f.LabelRegex(), f.LabelNegate()); !ok {
 				klog.V(2).Infof("#%d labels do not meet %s", i.GetNumber(), f.LabelRegex())

--- a/pkg/provider/filter.go
+++ b/pkg/provider/filter.go
@@ -40,6 +40,10 @@ type Filter struct {
 	milestoneRegex  *regexp.Regexp
 	milestoneNegate bool
 
+	RawAuthor    string `yaml:"author,omitempty"`
+	authorRegex  *regexp.Regexp
+	authorNegate bool
+
 	Created            string `yaml:"created,omitempty"`
 	Updated            string `yaml:"updated,omitempty"`
 	Closed             string `yaml:"closed,omitempty"`
@@ -119,6 +123,28 @@ func (f *Filter) TitleRegex() *regexp.Regexp {
 
 func (f *Filter) TitleNegate() bool {
 	return f.titleNegate
+}
+
+// LoadAuthorRegex loads a new author regex
+func (f *Filter) LoadAuthorRegex() error {
+	r, negateState := negativeMatch(f.RawAuthor)
+
+	re, err := regex(r)
+	if err != nil {
+		return err
+	}
+
+	f.authorRegex = re
+	f.authorNegate = negateState
+	return nil
+}
+
+func (f *Filter) AuthorRegex() *regexp.Regexp {
+	return f.authorRegex
+}
+
+func (f *Filter) AuthorNegate() bool {
+	return f.authorNegate
 }
 
 // LoadMilestoneRegex loads a new milestone regex

--- a/pkg/triage/triage.go
+++ b/pkg/triage/triage.go
@@ -322,6 +322,13 @@ func processRules(raw map[string]Rule) (map[string]Rule, error) {
 				}
 			}
 
+			if f.RawAuthor != "" {
+				err := f.LoadAuthorRegex()
+				if err != nil {
+					return rules, fmt.Errorf("%q author: %w", id, err)
+				}
+			}
+
 			newfs = append(newfs, f)
 		}
 


### PR DESCRIPTION
Closes: https://github.com/google/triage-party/issues/192
Maybe also: https://github.com/google/triage-party/issues/264

Adds a regex filter that checks author of a PR so you can do same regex filtering on it as with title. It uses `i.GetUser().Login` as the string to match (so cannot be used on full name but that does not seem important).

Our usecase for this is to have a table with team PRs and separate ones for external ones. This usecase would also be served by https://github.com/google/triage-party/pull/266 to be honest but I did not notice it before and I think this may still be useful.

The code is just copy pasting existing regex filters code.

This is a draft mainly to check the naming and get some feedback on whether I am forgetting to add something somewhere to make this work consistently, naming etc.

TODO:
- [ ] docs
- [ ] ???  