### PR TITLE
fix skaffold.yaml to make sure skaffold dev works on triage party

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -18,7 +18,7 @@ metadata:
   name: teaparty
 build:
   artifacts:
-    - image: gcr.io/tstromberg-test/tparty
+  - image: tparty
   tagPolicy:
     sha256: {}
   local:
@@ -27,6 +27,9 @@ build:
 deploy:
   kubectl:
     manifests:
-      - kubernetes-manifests/deployment.yaml
-      - kubernetes-manifests/service.yaml
-      - ''
+    - deploy/kubernetes/*.yaml
+portForward:
+- resourceName: triage-party
+  resourceType: Service
+  namespace: triage-party
+  port: 8080


### PR DESCRIPTION
Fixed skaffold.yaml to make sure running skaffold dev and port forwarding works on traige-party
```
skaffold dev -d gcr.io/tejal-gke1
Listing files to watch...
 - tparty
Generating tags...
 - tparty -> gcr.io/tejal-gke1/tparty:latest
Checking cache...
 - tparty: Found Remotely
Starting test...
WARN[0149] Ignoring image referenced by digest: [gcr.io/tejal-gke1/tparty:latest@sha256:d25c8d79196c9f0aeb5da22012b71befaafd46eed79b8a86b5b3d9394579a0a8] 
Tags used in deployment:
 - tparty -> gcr.io/tejal-gke1/tparty:latest@sha256:d25c8d79196c9f0aeb5da22012b71befaafd46eed79b8a86b5b3d9394579a0a8
Starting deploy...
 - namespace/triage-party unchanged
 - configmap/triage-party-config unchanged
 - deployment.apps/triage-party unchanged
 - service/triage-party unchanged
Waiting for deployments to stabilize...
 - triage-party:deployment/triage-party is ready.
Deployments stabilized in 1.777 second
Press Ctrl+C to exit
Watching for changes...
Port forwarding Service/triage-party in namespace triage-party, remote port 8080 -> 127.0.0.1:8080
```
