### PR TITLE
Update Github CLI access token location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ docker run \
 
 You can also use Personal Access Token from [the GitHub CLI](https://github.com/cli/cli) to run the application:
 ```shell
-export GITHUB_TOKEN=$(grep oauth_token ~/.config/gh/config.yml| cut -d ":" -f 2 | sed "s/ //g")
+export GITHUB_TOKEN=$(grep oauth_token ~/.config/gh/hosts.yml| cut -d ":" -f 2 | sed "s/ //g")
 docker build --tag=tp .
 docker run \
   --rm \


### PR DESCRIPTION
It looks like the gh cli has changed where it stores the token.

I'm not totally sure about this change - I'm sure it might not work properly with on-prem github installations, but then I'm not sure if the original config did either.