### PR TITLE
Scope repos to collections

### DIFF
--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -156,7 +156,8 @@ func executeRule(ctx context.Context, tp *triage.Party) {
 		Hidden:    false,
 	}
 
-	rr, err := tp.ExecuteRule(ctx, sp, r, nil)
+	// TODO: Test collection repos
+	rr, err := tp.ExecuteRule(ctx, sp, r, nil, nil)
 	if err != nil {
 		klog.Exitf("execute: %v", err)
 	}

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,6 +54,39 @@ For collections, there are a few useful settings to mention:
 * `dedup` (bool): whether to filter out duplicate issues/PR's that show up among multiple rules
 * `display`: whether to show this page as `kanban` or `default`
 * `overflow`: flag issues if there are issues within a Kanban cell above or equal to this number
+* `repos`: an optional list of repos to pull from for this collection
+
+### Scoped Collections
+
+If you maintain a lot of projects, you may want to have a common set of rules applied to different collections, with each collection scoped to a different set of repos.  For example:
+
+```yaml
+# YAML anchor to define a reusable set of rules
+triage-rules: &triage-rules
+  - issue-needs-type
+  - issue-needs-priority
+  - question-needs-answer
+
+# YAML anchor to define a reusable set of repos
+player-repos: &player-repos
+  - https://github.com/shaka-project/shaka-player
+  - https://github.com/shaka-project/eme-encryption-scheme-polyfill
+
+# YAML anchor to define a reusable set of repos
+packager-repos: &packager-repos
+  - https://github.com/shaka-project/shaka-packager
+
+collections:
+  - id: shaka-player
+    name: Player Triage
+    rules: *triage-rules
+    repos: *player-repos
+
+  - id: shaka-packager
+    name: Packager Triage
+    rules: *triage-rules
+    repos: *packager-repos
+```
 
 ## Rules
 

--- a/pkg/triage/collection.go
+++ b/pkg/triage/collection.go
@@ -31,6 +31,7 @@ type Collection struct {
 	Name         string   `yaml:"name"`
 	Description  string   `yaml:"description,omitempty"`
 	RuleIDs      []string `yaml:"rules"`
+	Repos        []string `yaml:"repos,omitempty"`
 	Dedup        bool     `yaml:"dedup,omitempty"`
 	Hidden       bool     `yaml:"hidden,omitempty"`
 	UsedForStats bool     `yaml:"used_for_statistics,omitempty"`
@@ -94,7 +95,7 @@ func (p *Party) ExecuteCollection(ctx context.Context, s Collection, newerThan t
 			NewerThan: newerThan,
 			Hidden:    hidden,
 		}
-		ro, err := p.ExecuteRule(ctx, sp, t, seen)
+		ro, err := p.ExecuteRule(ctx, sp, t, seen, &s)
 		if err != nil {
 			return nil, fmt.Errorf("rule %q: %w", t.Name, err)
 		}

--- a/pkg/triage/rule.go
+++ b/pkg/triage/rule.go
@@ -121,10 +121,16 @@ func SummarizeRuleResult(t Rule, cs []*hubbub.Conversation, seen map[string]*Rul
 }
 
 // ExecuteRule executes a rule. seen is optional.
-func (p *Party) ExecuteRule(ctx context.Context, sp provider.SearchParams, t Rule, seen map[string]*Rule) (*RuleResult, error) {
+func (p *Party) ExecuteRule(ctx context.Context, sp provider.SearchParams, t Rule, seen map[string]*Rule, s *Collection) (*RuleResult, error) {
 	klog.V(1).Infof("executing rule %q for results newer than %s", t.ID, logu.STime(sp.NewerThan))
 	rcs := []*hubbub.Conversation{}
 	oldest := time.Now()
+
+	if s != nil {
+		if len(t.Repos) == 0 && len(s.Repos) > 0 {
+			t.Repos = s.Repos
+		}
+	}
 
 	for _, repoUrl := range t.Repos {
 		r, err := parseRepo(repoUrl)

--- a/pkg/triage/rule.go
+++ b/pkg/triage/rule.go
@@ -127,7 +127,7 @@ func (p *Party) ExecuteRule(ctx context.Context, sp provider.SearchParams, t Rul
 	oldest := time.Now()
 
 	if s != nil {
-		if len(t.Repos) == 0 && len(s.Repos) > 0 {
+		if len(s.Repos) > 0 {
 			t.Repos = s.Repos
 		}
 	}


### PR DESCRIPTION
This PR adds a `Repos` field to Collections and uses those repos for any rules that don't have repos defined.

Completed version of PR #263 by @eddiezane

Closes #262