### PR TITLE
chore: update skaffold triage-site config and deploy script

### DIFF
--- a/config/examples/skaffold.yaml
+++ b/config/examples/skaffold.yaml
@@ -139,6 +139,25 @@ collections:
       - milestone-pr-needs-merge
       - milestone-recently-closed
 
+  - id: planning
+    name: Planning
+    description: >
+      Skafold Team Planning Board.
+
+      This board is used by Skaffold team to plan upcoming releases.
+      The timeline and priority of issues listed here are subject to change.
+
+      Please add label planning/Q4-21 for an issue to appear on this board.
+
+    display: planning
+    rules:
+      - onboarding
+      - extensibility
+      - partner-requests
+      - skaffold-v2
+      - docs
+      - all-other-requests
+
   - id: similar
     name: Similar
     description: Items which appear similar to one other. Review for duplicates or vague titles.
@@ -183,6 +202,7 @@ rules:
     filters:
       - tag: "!commented"
       - tag: "recv"
+      - label: "!source/partnerships"
       - created: +7d
 
   issue-p0-followup-slo:
@@ -276,6 +296,7 @@ rules:
     filters:
       - tag: "!commented"
       - tag: "recv"
+      - label: "!source/partnerships"
       - created: -5d
 
   # Issues that may need reprioritized
@@ -680,6 +701,57 @@ rules:
       - tag: open-milestone
       - state: closed
       - updated: -21d
+  ## Planing
+  onboarding:
+    name: >
+      Simple Onboarding, Faster dev.
+      Use Label - area/onboarding
+    type: issue
+    filters:
+      - label: "planning/Q4-21"
+      - label: "area/onboarding"
+
+  extensibility:
+    name: >
+      Extensibility - Deploy and Lifecyle.
+      Use Label area/extensibility
+    type: issue
+    filters:
+      - label: "planning/Q4-21"
+      - label: "area/extensibility"
+
+  skaffold-v2:
+    name: >
+      Skaffold V2 pipeline.
+      Use Label area/V2
+    type: issue
+    filters:
+    - label: "planning/Q4-21"
+    - label: "area/extensibility"
+
+  partner-requests:
+    name: >
+      Other partner requests.
+      Use Label source/partnerships
+    type: issue
+    filters:
+      - label: "planning/Q4-21"
+      - label: "source/partnerships"
+
+  docs:
+    name: >
+      Skaffold Docs.
+      Use label area/docs
+    type: issue
+    filters:
+    - label: "planning/Q4-21"
+    - label: "area/docs"
+
+  all-other-requests:
+    name: "Others"
+    type: issue
+    filters:
+      - label: "planning/Q4-21"
 
   # Fix-It
   fixit-prs:

--- a/deploy/cloudrun/skaffold-deploy.sh
+++ b/deploy/cloudrun/skaffold-deploy.sh
@@ -17,7 +17,6 @@
 set -eux
 
 # Export this environment variable before running this script
-echo "token path: ${GITHUB_TOKEN_PATH}"
 
 export PROJECT=k8s-skaffold
 IMAGE="gcr.io/k8s-skaffold/teaparty:$(date +%F-%s)"
@@ -25,15 +24,15 @@ export
 export SERVICE_NAME=skaffold-triage-party
 export CONFIG_FILE=config/examples/skaffold.yaml
 
-docker build -t "${IMAGE}" --build-arg "CFG=${CONFIG_FILE}" .
+docker build -t "${IMAGE}" --build-arg "CFG=${CONFIG_FILE}" --platform="linux/amd64" .
 
 docker push "${IMAGE}" || exit 2
 
-readonly token="$(cat "${GITHUB_TOKEN_PATH}")"
 gcloud beta run deploy "${SERVICE_NAME}" \
     --project "${PROJECT}" \
     --image "${IMAGE}" \
-    --set-env-vars="GITHUB_TOKEN=${token},PERSIST_BACKEND=cloudsql,PERSIST_PATH=host=k8s-skaffold:us-central1:triage-party2 user=postgres password=${DB_PASS}" \
+    --set-env-vars="PERSIST_BACKEND=cloudsql"\
+    --update-secrets=GITHUB_TOKEN=triage-party-github-token:latest,PERSIST_PATH=triage-party-persist-path:latest\
     --allow-unauthenticated \
     --region us-central1 \
     --memory 384Mi \


### PR DESCRIPTION
Description:
 - change triage party skaffold.yaml config to be the same as the one in skaffold repo https://github.com/GoogleContainerTools/skaffold/blob/main/deploy/triage-party/skaffold.yaml
 - replace reading env variable with getting those from secret manager, so cloudRun yaml can hide those sensitive info 
 - after updating those and re-deploy skaffold triage party site, the secrets config looks like below -- no sensitive info exposed. 
![Screen Shot 2022-11-08 at 6 34 21 PM](https://user-images.githubusercontent.com/102683393/200698817-b644743c-2e86-464c-924d-791e24aa5f49.png)
