### PR TITLE
 fix: Resolve klog format errors, update CI workflow, and bump to Go 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build image
         run: docker build --tag=tp .
@@ -35,9 +35,9 @@ jobs:
     name: Static Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2 # required
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5 # required
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.15.1
-      - uses: pre-commit/action@v2.0.0
+          go-version: '1.25'
+      - uses: pre-commit/action@v3.0.1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REGISTRY ?= gcr.io/k8s-minikube
 TAG ?= v0.0.13
 
 .PHONY: push-latest-dev-image
-push-latest-dev-image: 
+push-latest-dev-image:
 	docker login gcr.io/k8s-minikube
 	docker buildx create --name multiarch --bootstrap
 	docker buildx build --push --builder multiarch --platform linux/amd64,linux/arm64 -t $(REGISTRY)/triage-party:$(TAG) -t $(REGISTRY)/triage-party:latest .

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/google/triage-party
 
-go 1.23.0
-
-toolchain go1.24.6
+go 1.25.0
 
 require (
 	github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20200501161113-5e9e23d7cb91

--- a/pkg/hubbub/analyze.go
+++ b/pkg/hubbub/analyze.go
@@ -81,11 +81,11 @@ func (h *Engine) analyzeIssue(ctx context.Context, i *provider.Issue, sp provide
 	}
 
 	if !preFetchMatch(i, labels, sp.Filters) {
-		klog.V(1).Infof("#%d - %q did not match item filter: %s", i.GetNumber(), i.GetTitle(), sp.Filters)
+		klog.V(1).Infof("#%d - %q did not match item filter: %v", i.GetNumber(), i.GetTitle(), sp.Filters)
 		return nil
 	}
 
-	klog.V(1).Infof("#%d - %q made it past pre-fetch: %s", i.GetNumber(), i.GetTitle(), sp.Filters)
+	klog.V(1).Infof("#%d - %q made it past pre-fetch: %v", i.GetNumber(), i.GetTitle(), sp.Filters)
 
 	fetchComments := false
 	if needComments(i, sp.Filters) && i.GetComments() > 0 {
@@ -111,10 +111,10 @@ func (h *Engine) analyzeIssue(ctx context.Context, i *provider.Issue, sp provide
 	}
 
 	if !postFetchMatch(co, sp.Filters) {
-		klog.V(1).Infof("#%d - %q did not match post-fetch filter: %s", i.GetNumber(), i.GetTitle(), sp.Filters)
+		klog.V(1).Infof("#%d - %q did not match post-fetch filter: %v", i.GetNumber(), i.GetTitle(), sp.Filters)
 		return nil
 	}
-	klog.V(1).Infof("#%d - %q made it past post-fetch: %s", i.GetNumber(), i.GetTitle(), sp.Filters)
+	klog.V(1).Infof("#%d - %q made it past post-fetch: %v", i.GetNumber(), i.GetTitle(), sp.Filters)
 
 	updatedAt := h.mtime(i)
 	var timeline []*provider.Timeline
@@ -144,11 +144,11 @@ func (h *Engine) analyzeIssue(ctx context.Context, i *provider.Issue, sp provide
 	co.PullRequestRefs = h.updateLinkedPRs(ctx, sp, co)
 
 	if !postEventsMatch(co, sp.Filters) {
-		klog.V(1).Infof("#%d - %q did not match post-events filter: %s", i.GetNumber(), i.GetTitle(), sp.Filters)
+		klog.V(1).Infof("#%d - %q did not match post-events filter: %v", i.GetNumber(), i.GetTitle(), sp.Filters)
 		return nil
 	}
 
-	klog.V(1).Infof("#%d - %q made it past post-events: %s", i.GetNumber(), i.GetTitle(), sp.Filters)
+	klog.V(1).Infof("#%d - %q made it past post-events: %v", i.GetNumber(), i.GetTitle(), sp.Filters)
 	return co
 }
 
@@ -269,7 +269,7 @@ func (h *Engine) analyzePR(ctx context.Context, pr *provider.PullRequest, sp pro
 	}
 
 	if !postEventsMatch(co, sp.Filters) {
-		klog.V(1).Infof("#%d - %q did not match post-events filter: %s", pr.GetNumber(), pr.GetTitle(), sp.Filters)
+		klog.V(1).Infof("#%d - %q did not match post-events filter: %v", pr.GetNumber(), pr.GetTitle(), sp.Filters)
 		return nil
 	}
 

--- a/pkg/hubbub/item.go
+++ b/pkg/hubbub/item.go
@@ -244,7 +244,7 @@ func (h *Engine) isMember(user string, role string) bool {
 		return true
 	}
 
-	klog.V(1).Infof("%s (%s) is not considered a member: members=%s memberRoles=%s", user, role, h.members, h.memberRoles)
+	klog.V(1).Infof("%s (%s) is not considered a member: members=%v memberRoles=%v", user, role, h.members, h.memberRoles)
 	return false
 }
 
@@ -324,7 +324,7 @@ func (h *Engine) parseRefs(text string, co *Conversation, t time.Time) {
 		project := m[2]
 		i, err := strconv.Atoi(m[3])
 		if err != nil {
-			klog.Errorf("unable to parse int from %s: %v", err)
+			klog.Errorf("unable to parse int from %s: %v", m[3], err)
 			continue
 		}
 

--- a/pkg/hubbub/match.go
+++ b/pkg/hubbub/match.go
@@ -106,7 +106,7 @@ func preFetchMatch(i provider.IItem, labels []*provider.Label, fs []provider.Fil
 
 		if f.Reactions != "" || f.ReactionsPerMonth != "" || f.Commenters != "" || f.Comments != "" {
 			if !i.GetUpdatedAt().After(i.GetCreatedAt()) {
-				klog.V(1).Infof("#%d has no updates, but need one for: %s", i.GetNumber(), f)
+				klog.V(1).Infof("#%d has no updates, but need one for: %v", i.GetNumber(), f)
 				return false
 			}
 		}
@@ -182,7 +182,7 @@ func postEventsMatch(co *Conversation, fs []provider.Filter) bool {
 	for _, f := range fs {
 		if f.TagRegex() != nil {
 			if ok, _ := matchTag(co.Tags, f.TagRegex(), f.TagNegate()); !ok {
-				klog.V(4).Infof("#%d did not pass matchTag: %s vs %s %v", co.ID, co.Tags, f.TagRegex(), f.TagNegate())
+				klog.V(4).Infof("#%d did not pass matchTag: %v vs %s %v", co.ID, co.Tags, f.TagRegex(), f.TagNegate())
 				return false
 			}
 		}

--- a/pkg/hubbub/search.go
+++ b/pkg/hubbub/search.go
@@ -70,7 +70,7 @@ func (h *Engine) SearchAny(ctx context.Context, sp provider.SearchParams) ([]*Co
 func (h *Engine) SearchIssues(ctx context.Context, sp provider.SearchParams) ([]*Conversation, time.Time, error) {
 	sp.Filters = openByDefault(sp)
 	klog.V(1).Infof(
-		"Gathering raw data for %s/%s issues %s - newer than %s",
+		"Gathering raw data for %s/%s issues %v - newer than %s",
 		sp.Repo.Organization,
 		sp.Repo.Project,
 		sp.Filters,
@@ -143,14 +143,14 @@ func (h *Engine) SearchIssues(ctx context.Context, sp provider.SearchParams) ([]
 		}
 
 		if seen[i.GetURL()] {
-			klog.Errorf("unusual: I already saw #%d", i.GetURL())
+			klog.Errorf("unusual: I already saw #%d", i.GetNumber())
 			continue
 		}
 		seen[i.GetURL()] = true
 		is = append(is, i)
 	}
 
-	klog.V(1).Infof("%s/%s aggregate issue count: %d, filtering for:\n%s", sp.Repo.Organization, sp.Repo.Project, len(is), sp.Filters)
+	klog.V(1).Infof("%s/%s aggregate issue count: %d, filtering for:\n%v", sp.Repo.Organization, sp.Repo.Project, len(is), sp.Filters)
 
 	// Avoids updating PR references on a quiet repository
 	latestIssueUpdate := time.Time{}
@@ -188,7 +188,7 @@ func NeedsClosed(fs []provider.Filter) bool {
 func (h *Engine) SearchPullRequests(ctx context.Context, sp provider.SearchParams) ([]*Conversation, time.Time, error) {
 	sp.Filters = openByDefault(sp)
 
-	klog.V(1).Infof("Gathering raw data for %s/%s PR's matching: %s - newer than %s",
+	klog.V(1).Infof("Gathering raw data for %s/%s PR's matching: %v - newer than %s",
 		sp.Repo.Organization, sp.Repo.Project, sp.Filters, logu.STime(sp.NewerThan))
 
 	var wg sync.WaitGroup

--- a/pkg/persist/mysql.go
+++ b/pkg/persist/mysql.go
@@ -94,7 +94,7 @@ func (m *MySQL) Set(key string, th *Blob) error {
 		ge := gob.NewEncoder(b)
 
 		if err := ge.Encode(th); err != nil {
-			klog.Errorf("encode: %w", err)
+			klog.Errorf("encode: %v", err)
 		}
 
 		_, err := m.db.Exec(`
@@ -130,7 +130,7 @@ func (m *MySQL) Get(key string, t time.Time) *Blob {
 	}
 
 	if err != nil {
-		klog.Errorf("query: %w", err)
+		klog.Errorf("query: %v", err)
 		return nil
 	}
 

--- a/pkg/persist/postgres.go
+++ b/pkg/persist/postgres.go
@@ -116,7 +116,7 @@ func (m *Postgres) Get(key string, t time.Time) *Blob {
 	}
 
 	if err != nil {
-		klog.Errorf("query: %w", err)
+		klog.Errorf("query: %v", err)
 		return nil
 	}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -47,7 +47,7 @@ func ReadToken(path string, envVar string) string {
 			klog.Exitf("unable to read token file: %v", err)
 		}
 		token := strings.TrimSpace(string(t))
-		klog.Infof("loaded %d byte %s token from %s", len(token), path)
+		klog.Infof("loaded %d byte token from %s", len(token), path)
 		return token
 	}
 
@@ -55,7 +55,7 @@ func ReadToken(path string, envVar string) string {
 	if token == "" {
 		klog.Warningf("No token found in environment variable %s (empty)", envVar)
 	} else {
-		klog.Infof("loaded %d byte %s token from %s", len(token), envVar)
+		klog.Infof("loaded %d byte token from %s", len(token), envVar)
 	}
 	return token
 }


### PR DESCRIPTION
Currently, the CI and local build environment are broken due to two main issues:

  1. GitHub Actions Deprecation: The CI workflow uses outdated actions (like  actions/checkout@v2  and  setup-go@v2 ) that rely on deprecated Node.js versions.
  2. Compilation/Test Failures: Running  go test ./...  fails due to multiple  `go vet`  errors flagged by  `klog`  format string mismatches. Modern Go  toolchains run  `go vet`  automatically during tests and treat these mismatches as hard build failures.

This PR resolves all these pre-existing infrastructure and code issues, restoring a green build status for the repository, and modernizes the project  to Go 1.25.